### PR TITLE
Fix theme-color meta tag not syncing with the theme

### DIFF
--- a/src/theme/book.js
+++ b/src/theme/book.js
@@ -346,7 +346,7 @@ function playground_text(playground, hidden = true) {
         }
 
         setTimeout(function () {
-            themeColorMetaTag.content = getComputedStyle(document.body).backgroundColor;
+            themeColorMetaTag.content = getComputedStyle(document.documentElement).backgroundColor;
         }, 1);
 
         if (window.ace && window.editors) {


### PR DESCRIPTION
Fixes #2117.

document.`body`.backgroundColor is always transparent (rgba(0, 0, 0, 0))
while
document.`documentElement`.backgroundColor gives the correct value.